### PR TITLE
Fix README inventor wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # powersmooth
-Python implementation of powersmooth (https://de.mathworks.com/matlabcentral/fileexchange/48799-powersmooth), invented from B. M. Friedrich.
+Python implementation of powersmooth (https://de.mathworks.com/matlabcentral/fileexchange/48799-powersmooth), invented by B. M. Friedrich.
 This version allowes to add intermediate points.


### PR DESCRIPTION
## Summary
- correct inventor reference in README
- retain MathWorks URL

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6862b30094cc8330b2b4ef4055573d42